### PR TITLE
Remove duplicate cIMAGES cleanup

### DIFF
--- a/Ultimate Arena.gmx/scripts/initialize_characters.gml
+++ b/Ultimate Arena.gmx/scripts/initialize_characters.gml
@@ -14,14 +14,6 @@ if(is_array(global.cIMAGES)){
 }
 global.cIMAGES = 0;
 
-if(is_array(global.cIMAGES)){
-    for(var i=0; i<array_length_1d(global.cIMAGES); i++){
-        if(global.cIMAGES[i] != spr_defaultFighterImage)
-            sprite_delete(global.cIMAGES[i]);
-    }
-}
-global.cIMAGES = 0;
-
 directory = 0;
 directory[0] = "";
 var l = initialize_directory("characters");


### PR DESCRIPTION
## Summary
- remove the redundant cleanup block for `global.cIMAGES` in the character initialization script so the array is only processed once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c87ea5c3308322a1c16f4f7a24d212