### PR TITLE
Destroy steam_list after processing

### DIFF
--- a/Ultimate Arena.gmx/scripts/initialize_characters.gml
+++ b/Ultimate Arena.gmx/scripts/initialize_characters.gml
@@ -105,7 +105,7 @@ var s = ds_list_size(steam_list);
 for(h=0;h<s;h++)
 {
     steam_map = ds_map_create();
-    steam_ugc_get_item_install_info(steam_list[| h], steam_map); 
+    steam_ugc_get_item_install_info(steam_list[| h], steam_map);
     //show_debug_message(steam_map [? "folder"]);
     
     
@@ -185,6 +185,7 @@ for(h=0;h<s;h++)
     file_find_close();
     ds_map_destroy(steam_map);
 }
+ds_list_destroy(steam_list);
 
 global.lNAME = i;
 global.fighters = i;

--- a/Ultimate Arena.gmx/scripts/initialize_events.gml
+++ b/Ultimate Arena.gmx/scripts/initialize_events.gml
@@ -59,4 +59,6 @@ for(h=0;h<s;h++)
     file_find_close();
     ds_map_destroy(steam_map);
 }
+ds_list_destroy(steam_list);
+ 
 global.EVENT_COUNT = i;


### PR DESCRIPTION
## Summary
- add ds_list_destroy calls to free Steam subscription lists after processing characters and events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c87eab46488322a7c421562545d6f4